### PR TITLE
remove group check when creating directory to store CA Keys 

### DIFF
--- a/tasks/sshd.yml
+++ b/tasks/sshd.yml
@@ -8,8 +8,7 @@
     state: directory
     mode: "0700"
     owner: "{{ ssh_local_user }}"
-    group: "{{ ssh_local_user }}"
-
+    
 - name: Download authorized CA keys from Vault
   delegate_to: "127.0.0.1"
   become: yes


### PR DESCRIPTION
since macs have different groups for users, and it's not necessary for copying the CA keys, remove the group check.