### PR TITLE
Add support for AWS_PROFILE env var

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,5 @@ ssh_vault_login_method: "aws"
 ssh_vault_url: "http://127.0.0.1:8200"
 ssh_local_user: devops
 ssh_max_auth_retries: 15
+# The AWS profile the role should use when running the vault commands
+ssh_aws_profile: "default"

--- a/tasks/sshd.yml
+++ b/tasks/sshd.yml
@@ -15,6 +15,8 @@
   become_user: "{{ ssh_local_user }}"
   shell:
     cmd: "vault login -address={{ ssh_vault_url }} -method={{ ssh_vault_login_method }} && vault read -address={{ ssh_vault_url }} -field=public_key {{ item.src }}/config/ca > /tmp/{{ ssh_local_user }}/{{ item.name }}"
+  environment:
+    AWS_PROFILE: "{{ ssh_aws_profile }}"
   with_items: "{{ ssh_vault_trusted_user_ca_keys }}"
 
 - name: Make sure the trusted CAs Directory exists


### PR DESCRIPTION
Since there's a possibility of the role being called in setups where the
AWS keys used by the playbook (or what calls the playbook) are different
from the keys used to log into vault, add support for specifying which
AWS profile to use when logging into vault.

Signed-off-by: Jason Rogena <jason@rogena.me>