### PR TITLE
Fixes Error When ssh_vault_trusted_user_ca_keys Empty

### DIFF
--- a/tasks/sshd.yml
+++ b/tasks/sshd.yml
@@ -50,6 +50,7 @@
     owner: "root"
     group: "root"
     mode: "0644"
+  when: ssh_vault_trusted_user_ca_keys|length > 0
   notify:
     - "reload ssh"
 
@@ -81,5 +82,6 @@
   lineinfile:
     path: "/etc/ssh/sshd_config"
     line: "TrustedUserCAKeys /etc/ssh/ca/{{ ssh_ca_file }}"
+  when: ssh_vault_trusted_user_ca_keys|length > 0
   notify:
     - "reload ssh"


### PR DESCRIPTION
Since an empty ssh_vault_trusted_user_ca_keys means that the combined ca
certificates file isn't created, the role errored when it could not find
this file in cases where the list was empty. This PR fixes this issue.

Signed-off-by: Jason Rogena <jason@rogena.me>