### PR TITLE
Switches to devsec.hardening.ssh_hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Performs the following tasks related to SSH in a host:
 
 1. Installs public SSH keys authorized to access the host.
 1. Installs SSH CA certificates from Hashicorp Vault authorized to access the host.
-1. Hardens the SSHD service (through [dev-sec.ssh-hardening](https://github.com/dev-sec/ansible-ssh-hardening)) by applying recommended secure configurations.
+1. Hardens the SSHD service (through devsec.hardening.ssh_hardening) by applying recommended secure configurations.
 
 Dependencies
 ------------
 
-- [dev-sec.ssh-hardening](https://github.com/dev-sec/ansible-ssh-hardening)
+- devsec.hardening.ssh_hardening provided by the [devsec.hardening](https://galaxy.ansible.com/devsec/hardening) collection.
 
 License
 -------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,6 @@ galaxy_info:
   categories:
     - ssh
 dependencies:
-  - role: dev-sec.ssh-hardening
+  - role: devsec.hardening.ssh_hardening
     vars:
       sshd_moduli_minimum: "{{ ssh_sshd_moduli_minimum }}"


### PR DESCRIPTION
Switches to devsec.hardening.ssh_hardening (provided by the
devsec.hardening) collection that supports more recent versions of
OpenSSH.

Signed-off-by: Jason Rogena <jason@rogena.me>