### PR TITLE
Add `ssh_become_local_user variable` to set `become` arg in tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ ssh_users:
     authorized_keys: []
 ssh_vault_login_method: "aws"
 ssh_vault_url: "http://127.0.0.1:8200"
+ssh_become_local_user: yes
 ssh_local_user: "{{ lookup('env','USER') }}"
 ssh_max_auth_retries: 15
 # The AWS profile the role should use when running the vault commands

--- a/tasks/sshd.yml
+++ b/tasks/sshd.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create temporary directory for storing authorized CA keys
   delegate_to: "127.0.0.1"
-  become: yes
+  become: "{{ ssh_become_local_user }}"
   become_user: "{{ ssh_local_user }}"
   file:
     path: "/tmp/{{ ssh_local_user }}"
@@ -11,7 +11,7 @@
 
 - name: Download authorized CA keys from Vault
   delegate_to: "127.0.0.1"
-  become: yes
+  become: "{{ ssh_become_local_user }}"
   become_user: "{{ ssh_local_user }}"
   shell:
     cmd: "vault login -address={{ ssh_vault_url }} -method={{ ssh_vault_login_method }} && vault read -address={{ ssh_vault_url }} -field=public_key {{ item.src }}/config/ca > /tmp/{{ ssh_local_user }}/{{ item.name }}"
@@ -21,7 +21,7 @@
 
 - name: Make sure the temporary combined CA certs file doesn't exist
   delegate_to: "127.0.0.1"
-  become: yes
+  become: "{{ ssh_become_local_user }}"
   become_user: "{{ ssh_local_user }}"
   file:
     path: "/tmp/{{ ssh_local_user }}/{{ ssh_ca_file }}"
@@ -29,7 +29,7 @@
 
 - name: Copy the downloaded CA keys to one file
   delegate_to: "127.0.0.1"
-  become: yes
+  become: "{{ ssh_become_local_user }}"
   become_user: "{{ ssh_local_user }}"
   shell:
     cmd: "cur_ssh_cert=`cat /tmp/{{ ssh_local_user }}/{{ item.name }}` && cur_ssh_cert=\"${cur_ssh_cert} {{ item.name }}\" && echo \"${cur_ssh_cert}\" >> /tmp/{{ ssh_local_user }}/{{ ssh_ca_file }}"


### PR DESCRIPTION
Allow specifying whether to become user using sudo or not. Setting
become_user as current user and setting become to true, requires a sudo
password be provided.

references onaio/infrastructure#3774