### PR TITLE
Ensure sshd is configured correctly on Ubuntu 22.04

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-ssh_x11_forwarding: "no"
 ssh_vault_trusted_user_ca_keys: []
 ssh_users:
   ubuntu:
@@ -8,10 +7,11 @@ ssh_vault_login_method: "aws"
 ssh_vault_url: "http://127.0.0.1:8200"
 ssh_become_local_user: yes
 ssh_local_user: "{{ lookup('env','USER') }}"
-ssh_max_auth_retries: 15
 # The AWS profile the role should use when running the vault commands
 ssh_aws_profile: "default"
 # The name of the file to place CA certificates inside /etc/ssh/ca/
 ssh_ca_file: "authorized"
+ssh_x11_forwarding: false
+ssh_max_auth_retries: 10
 ssh_sshd_moduli_minimum: 3071  # As recommended by Mozilla (March 2021) https://infosec.mozilla.org/guidelines/openssh
 ssh_trusted_user_ca_keys_file: "/etc/ssh/ca/{{ ssh_ca_file }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,5 +14,4 @@ ssh_aws_profile: "default"
 # The name of the file to place CA certificates inside /etc/ssh/ca/
 ssh_ca_file: "authorized"
 ssh_sshd_moduli_minimum: 3071  # As recommended by Mozilla (March 2021) https://infosec.mozilla.org/guidelines/openssh
-ssh_sshd_custom_options: 
-  - "TrustedUserCAKeys /etc/ssh/ca/{{ ssh_ca_file }}"
+ssh_trusted_user_ca_keys_file: "/etc/ssh/ca/{{ ssh_ca_file }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,8 @@ ssh_local_user: "{{ lookup('env','USER') }}"
 ssh_aws_profile: "default"
 # The name of the file to place CA certificates inside /etc/ssh/ca/
 ssh_ca_file: "authorized"
-ssh_x11_forwarding: false
-ssh_max_auth_retries: 10
+x11_forwarding: false
+max_auth_retries: 10
 ssh_sshd_moduli_minimum: 3071  # As recommended by Mozilla (March 2021) https://infosec.mozilla.org/guidelines/openssh
-ssh_trusted_user_ca_keys_file: "/etc/ssh/ca/{{ ssh_ca_file }}"
+ssh_sshd_custom_options:
+  - "TrustedUserCAKeys /etc/ssh/ca/{{ ssh_ca_file }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,4 +15,4 @@ dependencies:
   - role: devsec.hardening.ssh_hardening
     vars:
       sshd_moduli_minimum: "{{ ssh_sshd_moduli_minimum }}"
-      sshd_custom_options: "{{ ssh_sshd_custom_options }}"
+      ssh_trusted_user_ca_keys_file: "{{ ssh_trusted_user_ca_keys_file }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,3 +16,5 @@ dependencies:
     vars:
       sshd_moduli_minimum: "{{ ssh_sshd_moduli_minimum }}"
       ssh_trusted_user_ca_keys_file: "{{ ssh_trusted_user_ca_keys_file }}"
+      ssh_max_auth_retries: "{{ ssh_max_auth_retries }}"
+      ssh_x11_forwarding: "{{ ssh_x11_forwarding }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,6 @@ dependencies:
   - role: devsec.hardening.ssh_hardening
     vars:
       sshd_moduli_minimum: "{{ ssh_sshd_moduli_minimum }}"
-      ssh_trusted_user_ca_keys_file: "{{ ssh_trusted_user_ca_keys_file }}"
-      ssh_max_auth_retries: "{{ ssh_max_auth_retries }}"
-      ssh_x11_forwarding: "{{ ssh_x11_forwarding }}"
+      sshd_custom_options: "{{ ssh_sshd_custom_options }}"
+      ssh_max_auth_retries: "{{ max_auth_retries }}"
+      ssh_x11_forwarding: "{{ x11_forwarding }}"

--- a/tasks/sshd.yml
+++ b/tasks/sshd.yml
@@ -43,7 +43,7 @@
     group: root
     mode: "0755"
 
-- name: Copy the combined authrized CA certs file
+- name: Copy the combined authorized CA certs file
   copy:
     src: "/tmp/{{ ssh_local_user }}/{{ ssh_ca_file }}"
     dest: "/etc/ssh/ca/{{ ssh_ca_file }}"
@@ -51,21 +51,5 @@
     group: "root"
     mode: "0644"
   when: ssh_vault_trusted_user_ca_keys|length > 0
-  notify:
-    - "reload ssh"
-
-- name: Set value for X11Forwarding
-  lineinfile:
-    path: "/etc/ssh/sshd_config"
-    line: "X11Forwarding {{ ssh_x11_forwarding }}"
-    regexp: '^X11Forwarding'
-  notify:
-    - "reload ssh"
-
-- name: Set value for MaxAuthTries
-  lineinfile:
-    path: "/etc/ssh/sshd_config"
-    line: "MaxAuthTries {{ ssh_max_auth_retries }}"
-    regexp: '^MaxAuthTries'
   notify:
     - "reload ssh"

--- a/tasks/sshd.yml
+++ b/tasks/sshd.yml
@@ -69,19 +69,3 @@
     regexp: '^MaxAuthTries'
   notify:
     - "reload ssh"
-
-- name: Delete all the TrustedUserCAKeys from SSHD config
-  lineinfile:
-    path: "/etc/ssh/sshd_config"
-    regexp: '^TrustedUserCAKeys'
-    state: absent
-  notify:
-    - "reload ssh"
-
-- name: Add trusted user CA certificate file to SSHD config
-  lineinfile:
-    path: "/etc/ssh/sshd_config"
-    line: "TrustedUserCAKeys /etc/ssh/ca/{{ ssh_ca_file }}"
-  when: ssh_vault_trusted_user_ca_keys|length > 0
-  notify:
-    - "reload ssh"


### PR DESCRIPTION
# Changes

- Ensure trusted CA key is actually picked up on Ubuntu 22.04+
- Remove tasks that are not really needed since they're configurable on the devsec.hardening.ssh_hardening role

## More Info

The devsec.hardening.ssh_hardening role template does not set any
default TrustedUserCAKeys so there is no need to remove and replace the
entry.

Removing the entry and adding it at the end causes the CA to not be
picked up in Ubuntu 22.04. This can be tested by running the previos
version of the role before the commit and running `sshd -T` you'll
notice that the TrustedUserCAKeys is set to none